### PR TITLE
Implement simple JSON cache example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # gptrepo
+
+Questo repository contiene un semplice esempio di utilizzo della cache in locale di un file JSON.
+
+Aprire `index.html` in un browser per vedere come viene scaricato `data.json` e come la versione più recente viene salvata in `localStorage` con controllo di checksum.
+
+

--- a/data.json
+++ b/data.json
@@ -1,0 +1,3 @@
+{
+  "messaggio": "ciao"
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="utf-8">
+  <title>Esempio Cache JSON</title>
+  <script>
+  async function sha256(str) {
+    const data = new TextEncoder().encode(str);
+    const hash = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(hash))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  async function loadJson() {
+    try {
+      const response = await fetch('data.json');
+      const text = await response.text();
+      const checksum = await sha256(text);
+      const storedChecksum = localStorage.getItem('dataJsonChecksum');
+      if (checksum !== storedChecksum) {
+        localStorage.setItem('dataJson', text);
+        localStorage.setItem('dataJsonChecksum', checksum);
+        console.log('JSON aggiornato dalla rete');
+      } else {
+        console.log('JSON dalla cache');
+      }
+      const jsonData = JSON.parse(localStorage.getItem('dataJson'));
+      console.log('Dati:', jsonData);
+    } catch (err) {
+      console.warn('Errore rete, uso la versione in cache se disponibile', err);
+      const jsonText = localStorage.getItem('dataJson');
+      if (jsonText) {
+        const data = JSON.parse(jsonText);
+        console.log('Dati dalla cache:', data);
+      } else {
+        console.error('Nessun dato in cache');
+      }
+    }
+  }
+
+  window.addEventListener('load', loadJson);
+  </script>
+</head>
+<body>
+  <h1>Esempio Cache JSON</h1>
+  <p>Apri la console per vedere i log.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a demo `index.html` that caches `data.json` in `localStorage`
- provide sample `data.json`
- document how to use the example in `README.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402cb1be5c8324b5005b6725718ab5